### PR TITLE
fix Trimet custom directions

### DIFF
--- a/backend/agencies/trimet.yaml
+++ b/backend/agencies/trimet.yaml
@@ -3,56 +3,7 @@ gtfs_url: https://developer.trimet.org/schedule/gtfs.zip
 gtfs_agency_id: TRIMET
 timezone_id: America/Los_Angeles
 custom_directions:
-  '15':
-    - id: "0"
-      title: "To NW Yeon & 44th"
-      gtfs_direction_id: "0"
-      included_stop_ids: ["6470"]
-    - id: "0-T"
-      title: "To NW Thurman & 27th"
-      gtfs_direction_id: "0"
-      included_stop_ids: ["5836"]
-    - id: "1"
-      title: "From NW Yeon & 44th to Gateway Transit Center"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["6470"]
-    - id: "1-T"
-      title: "From NW Thurman & 28th to Gateway Transit Center"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["5835"]
   '50':
-    - id: "0"
-      title: "Evening Loop"
-      gtfs_direction_id: "0"
-    - id: "1"
-      title: "Morning Loop"
-      gtfs_direction_id: "1"
-  '51':
-    - id: "0-CC"
-      title: "To Council Crest & Tualatin"
-      gtfs_direction_id: "0"
-      included_stop_ids: ["1218"]
-      excluded_stop_ids: ["2467"]
-    - id: "0-HD"
-      title: "To Hamilton & Dosch"
-      gtfs_direction_id: "0"
-      included_stop_ids: ["2467"]
-      excluded_stop_ids: ["1218"]
-    - id: "1-CC"
-      title: "From Council Crest to Portland City Center"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["2467"]
-      excluded_stop_ids: ["1218"]
-    - id: "1-HD"
-      title: "From Hamilton & Dosch to Portland City Center"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["1218"]
-      excluded_stop_ids: ["2467"]
-    - id: "1"
-      title: "From Council Crest to Portland City Center via Hamilton & Dosch"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["1218","2467","7098"]
-  '53':
     - id: "0"
       title: "Evening Loop"
       gtfs_direction_id: "0"


### PR DESCRIPTION
`save_routes.py` was encountering errors when parsing the latest static GTFS feed from Trimet because some routes have been modified since we last updated the `custom_directions` configuration with particular direction IDs and stop IDs. This PR removes the custom_directions specifications for the affected routes for now, so that `save_routes.py` can save the updated Trimet route configuration. Later we can look into adding any necessary custom_directions back again.