### PR TITLE
use aiohttp to fetch multiple state files from S3 in parallel; update format of cached state CSV file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM python:3.7.2-slim-stretch AS flask-dev
 RUN mkdir -p /app/backend && \
     apt-get update && \
     apt-get install -y curl nano less sudo
+RUN pip install pip==22.0.3
 COPY ./backend/requirements.txt /app/backend/requirements.txt
 RUN pip install -r /app/backend/requirements.txt
 COPY ./backend /app/backend

--- a/backend/models/vehicle_positions.py
+++ b/backend/models/vehicle_positions.py
@@ -236,7 +236,7 @@ def get_state_cache_dir(agency_id):
     return os.path.join(
         source_dir,
         'data',
-        f"state_v3_{agency_id}",
+        f"state_v4_{agency_id}",
     )
 
 def get_route_temp_cache_path(agency_id: str, route_id: str) -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.8.1
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
@@ -16,7 +17,7 @@ pandas==0.24.1
 partridge==1.1.0
 python-dateutil==2.8.0
 pytz==2018.9
-requests==2.22.0
+requests==2.27.1
 six==1.12.0
 urllib3>=1.24.2
 Werkzeug==0.15.3


### PR DESCRIPTION
This PR increases the speed of fetching vehicle position state files from S3 by using the `aiohttp` and `asyncio` libraries to fetch multiple state files from S3 in parallel.

On my development computer, fetching 24 hours of state files (approximately 5760 files) previously took 422 seconds to complete. With this PR the time was reduced to 82 seconds, a speedup of more than 5x.

This PR configures aiohttp to use 8 parallel requests to the S3 API. In practice, adding more than 8 parallel requests didn't seem to make it much faster.

The per-route cached state CSV files were also simplified. Previously the CSV contained `timestamp` and `secsSinceReport` columns. When the state file was loaded, the "real" timestamp was calculated by subtracting the two values. This PR just subtracts the two values first and stores the result in the `timestamp` column of the CSV. Also, the CSV previously contained a `directionId` column. However, the reported direction ID for each vehicle was not actually used anywhere, so it was removed from the CSV file and eclipses.py was updated accordingly.

The lines in each CSV file are not necessarily sorted by timestamp, since the parallel requests don't necessarily complete in chronological order, so the lines are sorted by timestamp after reading the CSV file from disk.

This PR still fetches files from S3 in chunks of 1 hour, constructs a `route_csv_lines` dict in memory and then appends those CSV lines to each route cache file on disk at the end of each hour. Writing to the cache files in batches (after grouping CSV lines by route) first appears to be marginally faster than writing each CSV line directly to a cache file one at a time. 

To find opportunities for performance improvements, I used `cProfile` and `pstats` as described in https://docs.python.org/3/library/profile.html#profile.Profile . This motivated using the `@functools.lru_cache()` decorator to memoize the `get_state_cache_dir` function.

The `requests` library was also upgraded to avoid a warning when importing the library.

Since requirements.txt has changed, it is necessary to run `docker-compose build` in order to run the code in this PR.