### PR TITLE
skip 'run' job if 'check-aws-secret' doesn't detect the secret existing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,23 @@ defaults:
     working-directory: frontend
 
 jobs:
+  check-aws-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      key_exists: ${{ steps.check-secret.outputs.key_exists }}
+    steps:
+    - uses: actions/checkout@v1
+    - id: check-secret
+      name: Check if AWS secret exists
+      run: |-
+        if [ ! -z ${{ secrets.AWS_SECRET_ACCESS_KEY }} ]; then
+          echo "::set-output name=key_exists::true"
+        fi
+
   run:
     runs-on: ubuntu-latest
+    needs: [check-aws-secret]
+    if: ${{ needs.check-aws-secret.outputs.key_exists == 'true' }}
     steps:
     - uses: actions/checkout@v1
     - name: Configure AWS Credentials

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,9 @@ jobs:
     - id: check-secret
       name: Check if AWS secret exists
       run: |-
-        if [ ! -z ${{ secrets.AWS_SECRET_ACCESS_KEY }} ]; then
+        if [ ! -z ${{ secrets.AWS_SECRET_ACCESS_KEY }} ] && \
+           [ ! -z ${{ secrets.AWS_ACCESS_KEY_ID }} ] && \
+           [ ! -z ${{ secrets.S3_BUCKET }} ]; then
           echo "::set-output name=key_exists::true"
         fi
 


### PR DESCRIPTION
Temporary workaround for #22. GitHub Actions is janky in a lot of ways and this is one of those times; the "secrets" context can't be checked in a job `if` conditional.

So, this approach starts a job before `run` and outputs whether the secret exists. `run` will be skipped if it isn't detected.

The other approach would be to move the `check-secret` step in the `run` job and check there, but then all subsequent steps in that job will need an individual `if` check for whether the token existed or not. That seems less clean from a code perspective, to me.

Tested this works locally using https://github.com/nektos/act