### PR TITLE
16 isochrone dropdowns

### DIFF
--- a/frontend/src/screens/Isochrone.css
+++ b/frontend/src/screens/Isochrone.css
@@ -25,6 +25,10 @@
 {
     padding:5px;
     min-width: 140px;
+    z-index: 800;
+    position: absolute;
+    margin-left: 10px;
+    margin-top: 4.5rem;
 }
 
 .isochrone-legend

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -741,6 +741,58 @@ class Isochrone extends React.Component {
 
     return (
       <>
+
+        {/* Issue 16: When declared as Leaflet Control, the
+            select menus in Isochrone controls don't expand.
+            Declare the controls off the map and use CSS to
+            place them on top of the map.
+          */}
+        <div className="isochrone-controls">
+          <FormControl className="inline-form-control">
+            <InputLabel shrink>Date-Time Range</InputLabel>
+              <div style={{ paddingTop: '15px' }}>
+                <SingleDateControl />
+              </div>
+              <div>
+                <TimeRangeControl />
+              </div>
+          </FormControl>
+
+          <div>
+            <FormControl className="inline-form-control">
+              <InputLabel shrink>Max Trip Time</InputLabel>
+              <Select
+                value={this.state.maxTripMin}
+                onChange={this.handleMaxTripMinChange}>
+                {tripMins.map(tripMin => (
+                  <MenuItem key={tripMin} value={tripMin}>
+                    {tripMin} minutes
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </div>
+
+          <div style={{ paddingTop: 8 }}>
+            <InputLabel shrink id="routesLabel">
+              Routes
+            </InputLabel>
+            <Grid container direction="row" alignItems="flex-start">
+              <Grid item>
+                <Button size="small" onClick={this.selectAllRoutesClicked}>
+                  all
+                </Button>
+                <Button size="small" onClick={this.selectNoRoutesClicked}>
+                  none
+                </Button>
+              </Grid>
+            </Grid>
+            <List className="isochrone-routes">
+              {(routes || []).map(route => this.makeRouteToggle(route))}
+            </List>
+          </div>
+        </div>
+
         <Map
           center={this.initialCenter}
           zoom={this.initialZoom}
@@ -757,52 +809,6 @@ class Isochrone extends React.Component {
             opacity={0.6}
           />
           {/* see http://maps.stamen.com for details */}
-          <Control position="topleft" className="isochrone-controls">
-            <div ref={this.refContainer}>
-              <FormControl className="inline-form-control">
-                <InputLabel shrink>Date-Time Range</InputLabel>
-                <div style={{ paddingTop: '15px' }}>
-                  <SingleDateControl />
-                </div>
-                <div>
-                  <TimeRangeControl />
-                </div>
-              </FormControl>
-              <div>
-                <FormControl className="inline-form-control">
-                  <InputLabel shrink>Max Trip Time</InputLabel>
-                  <Select
-                    value={this.state.maxTripMin}
-                    onChange={this.handleMaxTripMinChange}
-                  >
-                    {tripMins.map(tripMin => (
-                      <MenuItem key={tripMin} value={tripMin}>
-                        {tripMin} minutes
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </div>
-              <div style={{ paddingTop: 8 }}>
-                <InputLabel shrink id="routesLabel">
-                  Routes
-                </InputLabel>
-                <Grid container direction="row" alignItems="flex-start">
-                  <Grid item>
-                    <Button size="small" onClick={this.selectAllRoutesClicked}>
-                      all
-                    </Button>
-                    <Button size="small" onClick={this.selectNoRoutesClicked}>
-                      none
-                    </Button>
-                  </Grid>
-                </Grid>
-                <List className="isochrone-routes">
-                  {(routes || []).map(route => this.makeRouteToggle(route))}
-                </List>
-              </div>
-            </div>
-          </Control>
           <Control position="topright">
             {this.state.tripInfo ? (
               <div className="isochrone-trip-info">{this.state.tripInfo}</div>

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -741,7 +741,6 @@ class Isochrone extends React.Component {
 
     return (
       <>
-
         {/* Issue 16: When declared as Leaflet Control, the
             select menus in Isochrone controls don't expand.
             Declare the controls off the map and use CSS to
@@ -750,12 +749,12 @@ class Isochrone extends React.Component {
         <div className="isochrone-controls">
           <FormControl className="inline-form-control">
             <InputLabel shrink>Date-Time Range</InputLabel>
-              <div style={{ paddingTop: '15px' }}>
-                <SingleDateControl />
-              </div>
-              <div>
-                <TimeRangeControl />
-              </div>
+            <div style={{ paddingTop: '15px' }}>
+              <SingleDateControl />
+            </div>
+            <div>
+              <TimeRangeControl />
+            </div>
           </FormControl>
 
           <div>
@@ -763,7 +762,8 @@ class Isochrone extends React.Component {
               <InputLabel shrink>Max Trip Time</InputLabel>
               <Select
                 value={this.state.maxTripMin}
-                onChange={this.handleMaxTripMinChange}>
+                onChange={this.handleMaxTripMinChange}
+              >
                 {tripMins.map(tripMin => (
                   <MenuItem key={tripMin} value={tripMin}>
                     {tripMin} minutes


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
Fixes #16. Makes Isochrone controls sibling of map, then uses CSS to position them on top of map below zoom controls.

