### PR TITLE
add download button using already existing geojson data

### DIFF
--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -72,9 +72,6 @@ const redIcon = new L.Icon({
   shadowSize: [41, 41],
 });
 
-// define the beginning of the master list for all geoJson shapes
-const allGeoShapes = JSON.parse('{"type":"FeatureCollection","features":[]}');
-
 const computeCache = {};
 
 function getDirectionInfo(directionId, routeInfo) {
@@ -138,6 +135,8 @@ class Isochrone extends React.Component {
     this.routeLayers = [];
     this.mapRef = React.createRef();
     this.geoJson = {};
+    // define the beginning of the master list for all geoJson shapes
+    this.allGeoShapes = this.defaultMasterListValue();
 
     this.handleMapClick = this.handleMapClick.bind(this);
     this.handleToggleRoute = this.handleToggleRoute.bind(this);
@@ -301,10 +300,12 @@ class Isochrone extends React.Component {
     const tripMin = data.tripMin;
     const reachableCircles = data.circles;
     this.geoJson = data.geoJson;
-    this.geoJson.properties.time = tripMin; // add a property so that each shape can be separated in geoJSON renderers
 
+    if (this.geoJson) {
+      this.geoJson.properties.time = tripMin; // add a property so that each shape can be separated in geoJSON renderers
+    }
     // add the coordinates from the current shape to the global list
-    allGeoShapes.features.push(this.geoJson);
+    this.allGeoShapes.features.push(this.geoJson);
 
     if (this.state.computeId !== data.computeId || !this.mapRef.current) {
       return;
@@ -630,6 +631,11 @@ class Isochrone extends React.Component {
     // event arg
     this.resetMap();
     this.geoJson = {};
+    this.allGeoShapes = this.defaultMasterListValue(); // clear the master list of geoshapes when the map is cleared
+  }
+
+  defaultMasterListValue() {
+    return JSON.parse('{"type":"FeatureCollection","features":[]}');
   }
 
   recomputeIsochrones() {
@@ -715,8 +721,8 @@ class Isochrone extends React.Component {
   }
 
   downloadGeoJSON() {
-    if (allGeoShapes) {
-      const blob = new Blob([JSON.stringify(allGeoShapes)],{type:'application/json'});
+    if (this.allGeoShapes) {
+      const blob = new Blob([JSON.stringify(this.allGeoShapes)],{type:'application/json'});
       const href = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = href;

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -301,6 +301,7 @@ class Isochrone extends React.Component {
     const tripMin = data.tripMin;
     const reachableCircles = data.circles;
     this.geoJson = data.geoJson;
+    this.geoJson.properties.time = tripMin // add a property so that each shape can be separated in geoJSON renderers
 
     // add the coordinates from the current shape to the global list
     allGeoShapes.features.push(this.geoJson)

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -73,7 +73,7 @@ const redIcon = new L.Icon({
 });
 
 // define the beginning of the master list for all geoJson shapes
-let allGeoShapes = JSON.parse('{"type":"Feature","geometry":{"type":"MultiPolygon","coordinates":[]}}');
+let allGeoShapes = JSON.parse('{"type":"FeatureCollection","features":[]}');
 
 const computeCache = {};
 
@@ -303,8 +303,7 @@ class Isochrone extends React.Component {
     this.geoJson = data.geoJson;
 
     // add the coordinates from the current shape to the global list
-    let coords = this.geoJson.geometry.coordinates
-    coords.forEach(coord => allGeoShapes.geometry.coordinates.push(coord))
+    allGeoShapes.features.push(this.geoJson)
 
     if (this.state.computeId !== data.computeId || !this.mapRef.current) {
       return;

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -629,6 +629,7 @@ class Isochrone extends React.Component {
   resetMapClicked() {
     // event arg
     this.resetMap();
+    this.geoJson = {};
   }
 
   recomputeIsochrones() {
@@ -858,18 +859,20 @@ class Isochrone extends React.Component {
               >
                 Clear map
               </Button>
-              <br />
-              <br />
-              <Button
+            </Control>
+          ) : null}
+          <Control position="bottomleft">
+            {!this.state.computing && this.layers.length !== 0 ? (
+            <Button
                 variant="contained"
                 color="primary"
                 size="small"
                 onClick={this.downloadGeoJSON}
               >
                 Download As GeoJSON
-              </Button>
-            </Control>
+            </Button>
           ) : null}
+          </Control>
         </Map>
       </>
     );

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -134,7 +134,7 @@ class Isochrone extends React.Component {
     this.tripLayers = [];
     this.routeLayers = [];
     this.mapRef = React.createRef();
-    this.geoJson = {}
+    this.geoJson = {};
 
     this.handleMapClick = this.handleMapClick.bind(this);
     this.handleToggleRoute = this.handleToggleRoute.bind(this);

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -134,6 +134,7 @@ class Isochrone extends React.Component {
     this.tripLayers = [];
     this.routeLayers = [];
     this.mapRef = React.createRef();
+    this.geoJson = {}
 
     this.handleMapClick = this.handleMapClick.bind(this);
     this.handleToggleRoute = this.handleToggleRoute.bind(this);
@@ -144,6 +145,7 @@ class Isochrone extends React.Component {
     this.onWorkerMessage = this.onWorkerMessage.bind(this);
     this.recomputeIsochrones = this.recomputeIsochrones.bind(this);
     this.maxTripMinChanged = this.maxTripMinChanged.bind(this);
+    this.downloadGeoJSON = this.downloadGeoJSON.bind(this);
 
     isochroneWorker.onmessage = this.onWorkerMessage;
 
@@ -295,7 +297,7 @@ class Isochrone extends React.Component {
   addReachableLocationsLayer(data) {
     const tripMin = data.tripMin;
     const reachableCircles = data.circles;
-    const geoJson = data.geoJson;
+    this.geoJson = data.geoJson;
 
     if (this.state.computeId !== data.computeId || !this.mapRef.current) {
       return;
@@ -308,7 +310,7 @@ class Isochrone extends React.Component {
     const layerOptions = tripMinOptions[`${tripMin}`] || defaultLayerOptions;
 
     const diffLayer = L.geoJson(
-      geoJson,
+      this.geoJson,
       Object.assign(
         { bubblingMouseEvents: false, fillOpacity: 0.4, stroke: false },
         layerOptions,
@@ -704,6 +706,19 @@ class Isochrone extends React.Component {
     );
   }
 
+  downloadGeoJSON() {
+    if (this.geoJson) {
+      const blob = new Blob([JSON.stringify(this.geoJson)],{type:'application/json'});
+      const href = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = href;
+      link.download = "geojson-export-" + this.props.date + ".json";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  }
+
   render() {
     const { routes } = this.props;
 
@@ -838,6 +853,14 @@ class Isochrone extends React.Component {
               </Button>
               <br />
               <br />
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                onClick={this.downloadGeoJSON}
+              >
+                Download As GeoJSON
+              </Button>
             </Control>
           ) : null}
         </Map>

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -73,7 +73,7 @@ const redIcon = new L.Icon({
 });
 
 // define the beginning of the master list for all geoJson shapes
-let allGeoShapes = JSON.parse('{"type":"FeatureCollection","features":[]}');
+const allGeoShapes = JSON.parse('{"type":"FeatureCollection","features":[]}');
 
 const computeCache = {};
 
@@ -301,10 +301,10 @@ class Isochrone extends React.Component {
     const tripMin = data.tripMin;
     const reachableCircles = data.circles;
     this.geoJson = data.geoJson;
-    this.geoJson.properties.time = tripMin // add a property so that each shape can be separated in geoJSON renderers
+    this.geoJson.properties.time = tripMin; // add a property so that each shape can be separated in geoJSON renderers
 
     // add the coordinates from the current shape to the global list
-    allGeoShapes.features.push(this.geoJson)
+    allGeoShapes.features.push(this.geoJson);
 
     if (this.state.computeId !== data.computeId || !this.mapRef.current) {
       return;

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -72,6 +72,9 @@ const redIcon = new L.Icon({
   shadowSize: [41, 41],
 });
 
+// define the beginning of the master list for all geoJson shapes
+let allGeoShapes = JSON.parse('{"type":"Feature","geometry":{"type":"MultiPolygon","coordinates":[]}}');
+
 const computeCache = {};
 
 function getDirectionInfo(directionId, routeInfo) {
@@ -298,6 +301,10 @@ class Isochrone extends React.Component {
     const tripMin = data.tripMin;
     const reachableCircles = data.circles;
     this.geoJson = data.geoJson;
+
+    // add the coordinates from the current shape to the global list
+    let coords = this.geoJson.geometry.coordinates
+    coords.forEach(coord => allGeoShapes.geometry.coordinates.push(coord))
 
     if (this.state.computeId !== data.computeId || !this.mapRef.current) {
       return;
@@ -707,8 +714,8 @@ class Isochrone extends React.Component {
   }
 
   downloadGeoJSON() {
-    if (this.geoJson) {
-      const blob = new Blob([JSON.stringify(this.geoJson)],{type:'application/json'});
+    if (allGeoShapes) {
+      const blob = new Blob([JSON.stringify(allGeoShapes)],{type:'application/json'});
       const href = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = href;

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -722,11 +722,13 @@ class Isochrone extends React.Component {
 
   downloadGeoJSON() {
     if (this.allGeoShapes) {
-      const blob = new Blob([JSON.stringify(this.allGeoShapes)],{type:'application/json'});
+      const blob = new Blob([JSON.stringify(this.allGeoShapes)], {
+        type: 'application/json',
+      });
       const href = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = href;
-      link.download = "geojson-export-" + this.props.date + ".json";
+      link.download = `geojson-export-${this.props.date}.json`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -869,15 +871,15 @@ class Isochrone extends React.Component {
           ) : null}
           <Control position="bottomleft">
             {!this.state.computing && this.layers.length !== 0 ? (
-            <Button
+              <Button
                 variant="contained"
                 color="primary"
                 size="small"
                 onClick={this.downloadGeoJSON}
               >
                 Download As GeoJSON
-            </Button>
-          ) : null}
+              </Button>
+            ) : null}
           </Control>
         </Map>
       </>


### PR DESCRIPTION
This would implement #11.

The calculations for the Isochrone page already exposed the data in a GeoJSON format; this PR adds a button so the user can download that data for the current route calculation shown.

Clicking the button will download a file of the name "geojson-export-'todays-date'.json".

Below is an example of the page with the new button, on the bottom-left: 
![image](https://user-images.githubusercontent.com/21225886/167063822-ea8cb6a7-f8cc-4d92-b849-adfe90fe891a.png)
