### PR TITLE
Onboarding update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The app currently supports San Francisco and Portland, but we're working to gene
 
 ## Getting involved
 
-[Our onboarding doc](https://bit.ly/opentransitpdx) is a great way to get started. It'll provide you instructions on joining our GitHub organization, our Slack, our Google Drive, etc.
+[Our onboarding doc](https://github.com/codeforpdx/opentransit-metrics/blob/master/docs/onboarding.md) is a great way to get started. It'll provide you instructions on joining our GitHub organization, our Slack, our Google Drive, etc.
 
 ### Contributing
 
@@ -50,8 +50,8 @@ If you need to install some new dependencies in the Docker images, you can rebui
 
 ### Troubleshooting
 
-| Error message | Solution |
-| --- | --- |
+| Error message                         | Solution                   |
+| ------------------------------------- | -------------------------- |
 | `Module not found: can't resolve ...` | Run `docker-compose build` |
 
 ## Your first pull request
@@ -73,7 +73,7 @@ GitHub automatically runs tests for each push to check for eslint errors. If esl
 When you make a Pull Request, we would suggest you deploy your branch to Heroku so that other
 team members can try out your feature.
 
-First, create an account  at [heroku.com](https://heroku.com) and
+First, create an account at [heroku.com](https://heroku.com) and
 [create an app](https://dashboard.heroku.com/apps). Follow the instructions to deploy
 using Heroku Git with an existing Git repository.
 
@@ -94,7 +94,7 @@ Then copy the link to this app and paste it in the PR.
 
 #### How Deployment Works
 
-(**TODO**) Once a PR is merged into master, Google Cloud Build  will automatically build
+(**TODO**) Once a PR is merged into master, Google Cloud Build will automatically build
 the latest code and deploy it to a cluster on Google Kubernetes Engine (GKE).
 The build steps are defined in `cloudbuild.yaml`.
 
@@ -107,19 +107,19 @@ The build steps are defined in `cloudbuild.yaml`.
 
 ### Frontend
 
-- **NPM** - for package management. We explicitly decided to *not* use Yarn, because both
-package managers offer similar performance, we were already using NPM for backend
-package management, and the Yarn roadmap did not offer compelling
-improvements going forward.
-- **React** - Selected for popularity, simple view, and speedy virtual DOM. Code lives in the `/frontend` directory.  It was built using
-[Create React App](https://facebook.github.io/create-react-app/docs/folder-structure).
+- **NPM** - for package management. We explicitly decided to _not_ use Yarn, because both
+  package managers offer similar performance, we were already using NPM for backend
+  package management, and the Yarn roadmap did not offer compelling
+  improvements going forward.
+- **React** - Selected for popularity, simple view, and speedy virtual DOM. Code lives in the `/frontend` directory. It was built using
+  [Create React App](https://facebook.github.io/create-react-app/docs/folder-structure).
 - **Material UI** - which we use over Bootstrap since MUI doesn't rely on jQuery. It has a
-popular React framework and looks great on mobile.
+  popular React framework and looks great on mobile.
 - **Redux** - for state management and to simplify our application and component interaction.
 - **Redux Thunk** - as middleware for Redux.
 - **React Hooks** - to manage interactions with state management.
 - **Functional Components** - We migrated away from ES6 React Components and toward React
-[Functional Components](https://reactjs.org/docs/components-and-props.html) due to the simpler component logic and the ability to use React Hooks that Functional Components offer.
+  [Functional Components](https://reactjs.org/docs/components-and-props.html) due to the simpler component logic and the ability to use React Hooks that Functional Components offer.
 - **ESLint** - Linting set in the format of AirBNB Style.
 - **Prettier** - Code formatter to maintain standard code format for the frontend code.
 - **Husky** - Pre-commit hook to trigger Prettier auto formatting before pushing to Github.
@@ -148,22 +148,23 @@ In order to allow React to automatically recompile the frontend code within the 
 Windows host computer, you can create a `docker-compose.override.yml` to enable CHOKIDAR_USEPOLLING like this:
 
 ```yml
-version: "3.7"
+version: '3.7'
 services:
   react-dev:
     environment:
-      CHOKIDAR_USEPOLLING: "true"
-      CHOKIDAR_INTERVAL: "2500"
+      CHOKIDAR_USEPOLLING: 'true'
+      CHOKIDAR_INTERVAL: '2500'
 ```
 
 This setting is not in the main docker-compose.yml file because CHOKIDAR_USEPOLLING causes high CPU/battery usage for developers using Mac OS X,
 and CHOKIDAR_USEPOLLING is not necessary on Mac OS X to automatically recompile the frontend code when it changes.
 
-### Mac M1 
+### Mac M1
+
 If you're developing within Docker on a Mac with an M1 chip, you need to change the docker-compose platform. Create a `docker-compose.override.yml` to enable specify the platform like this:
 
 ```yml
-version: "3.7"
+version: '3.7'
 services:
   flask-dev:
     platform: linux/amd64
@@ -176,6 +177,7 @@ services:
 By default, the app shows statistics for TriMet in Portland, Oregon. You can configure the transit agency displayed in the web app by setting the OPENTRANSIT_AGENCY_IDS environment variable.
 
 Other available agency IDs include:
+
 - `trimet` (TriMet in Portland, Oregon)
 - `portland-sc` (Portland Streetcar)
 - `muni` (San Francisco Muni)
@@ -196,4 +198,4 @@ After changing docker-compose.override.yml, you will need to re-run `docker-comp
 
 Please see [ADVANCED_DEV.md](docs/ADVANCED_DEV.md) for even more advanced information like computing arrival times and deploying to AWS.
 
-See [agencies.md](docs/agencies.md) for configuring for different agencies, and how the front end gets the configuration information.  Important for testing with other devices against your dev machine.
+See [agencies.md](docs/agencies.md) for configuring for different agencies, and how the front end gets the configuration information. Important for testing with other devices against your dev machine.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,57 @@
+# Welcome to OpenTransit!
+
+## Project summary
+
+OpenTransit is dedicated to empowering people around the world to work with local governments to improve public transit using data. The project originated at the San Francisco Brigade and we extended it to PDX. We’re doing this by visualizing real-time data of the TriMet system so riders understand bus speed and reliability, and using the data to improve the TriMet system.
+
+## Get started
+
+1. Join Code for PDX Slack.
+2. Post your email and GitHub name on the #opentransit-pdx channel and we’ll add you to our GitHub and Google Drive.
+3. Try our PDX MVP demo. What are the stats on your most common bus trip?
+
+## Ready to contribute?
+
+1. Get opentransit-metrics cloned and running on your computer.
+2. Play around with opentransit-metrics and see if you find any problems with the data or functionality. File an issue with the problem you found.
+3. Find a GitHub issue labeled “Good First Issue,” ideally one without anyone already assigned to it. Take a crack at it — ask on Slack if you have a question!
+
+- If someone’s already assigned to a task you want to work on, ask the team if that person is still working on it — sometimes people move on to other tasks, so you may be able to pick it up anyway.
+
+4. Join our virtual meeting on Thursdays at 7pm, with call information shared via the Slack channel.
+
+## Our development process
+
+1. Create a new GitHub branch.
+2. Build your feature.
+3. Make a pull request. Request reviews from members of the team; you’ll need their approval to merge.
+
+- Good people to ask for reviews:
+  - Data science -- youngj, benji
+  - Frontend -- ?
+  - Backend -- youngj, benji
+  - Code refactoring -- ?
+  - Deployment -- youngj
+  - UI/UX -- ?
+- When in doubt, ask more people for reviews!
+- Include screenshots whenever you’re building a frontend feature.
+
+## Introductory readings
+
+- OpenTransit Vision, Mission, Strategies, and Goals
+- (Amazon-Style) press release of our first app
+- Product specification for our MVP
+- OpenTransit Metrics Design Principles
+
+## Similar apps to play with
+
+- www.busstat.nyc — a similar project in NYC that we want to emulate
+- la.railstats.org — a similar project in LA that we want to emulate
+- MBTAviz — a great example of public transit visualization from Boston
+  - Also, read this Politico article about how some young Boston transit advocates found small ways to make big improvements to the MBTA
+- https://www.dcmetrohero.com/dashboard - a project in DC
+
+## Want to take on something bigger?
+
+🚧 Work in progress 🚧
+Great! Go to this board, where we prioritize our top issues. Pick one in the “High priority” or, even better, “Top 5” column, that matches your interests. Go to the issue and assign it to yourself.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -2,19 +2,19 @@
 
 ## Project summary
 
-OpenTransit is dedicated to empowering people around the world to work with local governments to improve public transit using data. The project originated at the San Francisco Brigade and we extended it to PDX. We’re doing this by visualizing real-time data of the TriMet system so riders understand bus speed and reliability, and using the data to improve the TriMet system.
+OpenTransit is dedicated to empowering people around the world to work with local governments to improve public transit using data. The project originated at the [San Francisco Brigade](https://muni.opentransit.city/) and we extended it to [PDX](http://opentransit-youngj.herokuapp.com/). We’re doing this by visualizing real-time data of the TriMet system so riders understand bus speed and reliability, and using the data to improve the TriMet system.
 
 ## Get started
 
-1. Join Code for PDX Slack.
-2. Post your email and GitHub name on the #opentransit-pdx channel and we’ll add you to our GitHub and Google Drive.
-3. Try our PDX MVP demo. What are the stats on your most common bus trip?
+1. Join [Code for PDX Slack](http://www.codeforpdx.org/welcome).
+2. Post your email and GitHub name on the **#opentransit-pdx** channel and we’ll add you to our [GitHub](https://github.com/codeforpdx/opentransit-metrics) and [Google Drive](https://drive.google.com/drive/folders/10usf0ddMH1Z8Q06ZsHqacKROm3xZ4NZe?usp=sharing).
+3. Try our [PDX MVP demo](http://opentransit-youngj.herokuapp.com/). What are the stats on your most common bus trip?
 
 ## Ready to contribute?
 
-1. Get opentransit-metrics cloned and running on your computer.
-2. Play around with opentransit-metrics and see if you find any problems with the data or functionality. File an issue with the problem you found.
-3. Find a GitHub issue labeled “Good First Issue,” ideally one without anyone already assigned to it. Take a crack at it — ask on Slack if you have a question!
+1. Get [opentransit-metrics](https://github.com/codeforpdx/opentransit-metrics) cloned and running on your computer.
+2. Play around with [opentransit-metrics](https://github.com/codeforpdx/opentransit-metrics) and see if you find any problems with the data or functionality. [File an issue](https://github.com/codeforpdx/opentransit-metrics/issues) with the problem you found.
+3. [Find a GitHub issue labeled “Good First Issue,”](https://github.com/codeforpdx/opentransit-metrics/labels/Good%20First%20Issue) ideally one without anyone already assigned to it. Take a crack at it — ask on Slack if you have a question!
 
 - If someone’s already assigned to a task you want to work on, ask the team if that person is still working on it — sometimes people move on to other tasks, so you may be able to pick it up anyway.
 
@@ -22,7 +22,7 @@ OpenTransit is dedicated to empowering people around the world to work with loca
 
 ## Our development process
 
-1. Create a new GitHub branch.
+1. [Create a new GitHub branch.](https://github.com/codeforpdx/opentransit-metrics)
 2. Build your feature.
 3. Make a pull request. Request reviews from members of the team; you’ll need their approval to merge.
 
@@ -38,20 +38,20 @@ OpenTransit is dedicated to empowering people around the world to work with loca
 
 ## Introductory readings
 
-- OpenTransit Vision, Mission, Strategies, and Goals
-- (Amazon-Style) press release of our first app
-- Product specification for our MVP
-- OpenTransit Metrics Design Principles
+- [OpenTransit Vision, Mission, Strategies, and Goals](https://docs.google.com/document/d/1Ch1RvSSxlmOMLQfvgyd2ipuXOiRh5YpB4fQMgtVI-EQ/edit)
+- [(Amazon-Style) press release of our first app](https://docs.google.com/document/d/10Sfw6ASFVpMMewSzZVZglEtvpyRwS9f_Dqpehk7Ilsk/edit#heading=h.az7fpa4ze61n)
+- [Product specification for our MVP](https://docs.google.com/document/d/1E6rPTom6rkc9QKQCriGeYL2Aqoo4dan6eCNMxYMENyI/edit#heading=h.8afsoeezzewv)
+- [OpenTransit Metrics Design Principles](https://docs.google.com/document/d/19soN0I69lygHuQbKbWlx7OKgHOek38MU2eMS0y3rH1s/edit)
 
 ## Similar apps to play with
 
-- www.busstat.nyc — a similar project in NYC that we want to emulate
-- la.railstats.org — a similar project in LA that we want to emulate
-- MBTAviz — a great example of public transit visualization from Boston
-  - Also, read this Politico article about how some young Boston transit advocates found small ways to make big improvements to the MBTA
-- https://www.dcmetrohero.com/dashboard - a project in DC
+- [www.busstat.nyc](http://www.busstat.nyc) — a similar project in NYC that we want to emulate
+- [la.railstats.org](https://la.railstats.org/) — a similar project in LA that we want to emulate
+- [MBTAviz](http://mbtaviz.github.io/) — a great example of public transit visualization from Boston
+  - Also, read this [Politico article](https://www.politico.com/magazine/story/2018/10/25/what-works-boston-transit-221839) about how some young Boston transit advocates found small ways to make big improvements to the MBTA
+- [https://www.dcmetrohero.com/dashboard](https://www.dcmetrohero.com/dashboard) - a project in DC
 
 ## Want to take on something bigger?
 
 🚧 Work in progress 🚧
-Great! Go to this board, where we prioritize our top issues. Pick one in the “High priority” or, even better, “Top 5” column, that matches your interests. Go to the issue and assign it to yourself.
+Great! Go to [this board](https://github.com/codeforpdx/opentransit-metrics/projects), where we prioritize our top issues. Pick one in the “High priority” or, even better, “Top 5” column, that matches your interests. Go to the issue and assign it to yourself.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -28,11 +28,11 @@ OpenTransit is dedicated to empowering people around the world to work with loca
 
 - Good people to ask for reviews:
   - Data science -- youngj, benji
-  - Frontend -- ?
+  - Frontend -- Curtis Barnard
   - Backend -- youngj, benji
   - Code refactoring -- ?
   - Deployment -- youngj
-  - UI/UX -- ?
+  - UI/UX -- Curtis Barnard
 - When in doubt, ask more people for reviews!
 - Include screenshots whenever you’re building a frontend feature.
 


### PR DESCRIPTION

## Proposed changes

- Add a markdown file to the docs folder with the onboarding information to make it more rapidly accessible than going to the google doc at: https://docs.google.com/document/d/1MJMMOdlzyBOVlvKHydSQLTaxcbNqkS1NQufxiJK9jDs/edit#
- Update the broken link on README to point to the new markdown file.

There is a lot of good info in the doc that would be great for first-timers, but also isn't necessary to show on the main README

