### PR TITLE
Notify Slack with the check s3 job on all failures

### DIFF
--- a/.github/workflows/check_s3.yml
+++ b/.github/workflows/check_s3.yml
@@ -38,18 +38,17 @@ jobs:
         minutes_since_last_collected=$(( (current_date_in_seconds-last_collected_in_seconds) / 60 ))
         if [ $minutes_since_last_collected -gt 5 ]; then
           echo "minutes_since_last_collected $minutes_since_last_collected"
-          echo "::set-output name=missing-data::true"
           exit 1
         fi
         echo "minutes_since_last_collected $minutes_since_last_collected"
 
     - id: slack-notification-on-failure
-      if: steps.compare-times.outputs.missing-data == 'true'
+      if: ${{ failure() }} 
       name: Slack Notification (S3 check found missing data)
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: "#ffa500"
-        SLACK_MESSAGE: "No new data in the S3 bucket since: ${{ steps.get-last-modified-s3.outputs.last_collected_date_output }}. Check process running https://github.com/codeforpdx/opentransit-collector."
+        SLACK_MESSAGE: "The Check S3 action has failed. No new data in the S3 bucket since: ${{ steps.get-last-modified-s3.outputs.last_collected_date_output }}. Check process running https://github.com/codeforpdx/opentransit-collector."
         SLACK_WEBHOOK: ${{ secrets.OPENTRANSIT_SLACK_WEBHOOK }}
         SLACK_USERNAME: "S3 Check GitHub Action"
         SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png


### PR DESCRIPTION
Small PR that will run the Slack notification step on all failures. The message will still contain the time of the last successful S3 poll, but it may be empty if the error is some other error. 

I don't think it's worth figuring out how to get granular enough to change the message depending on the failure type.