### PR TITLE
Update README to use the correct app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you'd like to work with us, get in touch on our Slack channel! [Join the Code
 
 ## About this repository
 
-This repo is for [our flagship app](http://muni.opentransit.city/), which uses historical transit data to help riders, transit advocates, and transit planners understand how well -- or how poorly -- transit systems are doing and find ways to improve them.
+This repo is for [our flagship app](https://opentransit-pdx.herokuapp.com/), which uses historical transit data to help riders, transit advocates, and transit planners understand how well -- or how poorly -- transit systems are doing and find ways to improve them.
 
 The app currently supports San Francisco and Portland, but we're working to generalize it to work easily for other cities.
 


### PR DESCRIPTION
Changed app link from https://muni.opentransit.city/ to https://opentransit-pdx.herokuapp.com/